### PR TITLE
Fix SimpleDataRealizedFunction

### DIFF
--- a/experimental/ServiceAttributes.idr
+++ b/experimental/ServiceAttributes.idr
@@ -1,0 +1,51 @@
+module ServiceAttributes
+%default total
+          
+
+-- attrType should represent the type of any service metadata that needs to be
+-- tracked, (e.g. costs, quality, dependencies, etc).  It should implement
+-- the Num interface to make Service composition a simple matter of combining
+-- attributes with (+) and (*) operations.
+data Service : (Num attrType) => (attrs : attrType) -> (t : Type) -> Type where
+     -- Construct a basic service
+     MkService : (Num attrType) => (a : attrType) ->  (f : t) -> Service a t
+     -- Prove that a sequence of services creates a valid service.
+     Sequence : (Num attrType) =>
+              {a1 : attrType} -> {a2 : attrType} ->
+              (Service a1 (t1 -> ti)) ->
+              (Service a2 (ti -> t2)) ->
+              (Service (a1 + a2) (t1 ->  t2))
+    -- There might be a reason to write a third constructor representing
+    -- branches in service composition, but for now we'll put that aside.
+
+
+
+-- These are just here to help me wrap my head
+-- around composing long types.
+data Test1 : Type
+data Test2 : Type
+data Test3 : Type
+data Test4 : Type
+
+
+smallFun : Test1 -> Test2
+
+medFun : Test2 -> Test3 -> Test4
+
+endFun : Test4 -> Test1
+
+
+
+smallService : Service 1.0 (Test1 -> Test2)
+
+medService : Service 2.0 (Test2 -> Test3 -> Test4)
+
+endService : Service 2.0 (Test4 -> Test1)
+
+
+
+composedService : Service 3.0 (Test1 -> Test3 -> Test4)
+composedService = Sequence smallService medService
+
+
+longService : Service 5.0 ()

--- a/experimental/SimpleDataRealizedFunction-test.idr
+++ b/experimental/SimpleDataRealizedFunction-test.idr
@@ -1,25 +1,35 @@
-module Main
-
 import SimpleDataRealizedFunction
+%default total
+
+-- module Main
+
+
 
 -- Realized incrementer
 incrementer : Int -> Int
 incrementer = (+1)
-rlz_incrementer : SimpleDataRealizedFunction (Int -> Int) -- 100 1.0
-rlz_incrementer = MkSimpleDataRealizedFunction incrementer
+
+
+rlz_incrementer : SimpleDataRealizedFunction (Int -> Int)  100 1.0
+rlz_incrementer = MkSimpleDataRealizedFunction incrementer 100 1.0
 
 -- Realized twicer
 twicer : Int -> Int
 twicer = (*2)
-rlz_twicer : SimpleDataRealizedFunction (Int -> Int) -- 500 0.9
-rlz_twicer = MkSimpleDataRealizedFunction twicer
+
+
+rlz_twicer : SimpleDataRealizedFunction (Int -> Int)  500 0.9
+rlz_twicer = MkSimpleDataRealizedFunction twicer 500 0.9
 
 -- Realized (twicer . incrementer).
-rlz_composition : SimpleDataRealizedFunction (Int -> Int) -- 600 0.9
+rlz_composition : SimpleDataRealizedFunction (Int -> Int)  600 0.9
 -- The following does not work because 601 ≠ 100+500 and 1.0 ≠ (min 1.0 0.9)
 -- rlz_composition : SimpleDataRealizedFunction (Int -> Int) 601 1.0
 rlz_composition = compose rlz_twicer rlz_incrementer
 
 -- Simple test, result should be (3+1)*2 = 8
-rslt : Int
-rslt = apply rlz_composition 3
+rslt : Int -> Int
+rslt = apply rlz_composition
+
+rsltTest : (rslt 3) = 8
+rsltTest = Refl

--- a/experimental/SimpleDataRealizedFunction.idr
+++ b/experimental/SimpleDataRealizedFunction.idr
@@ -3,10 +3,10 @@
 module SimpleDataRealizedFunction
 
 public export
-data SimpleDataRealizedFunction : (a -> b) -> (cost : Integer) -> (quality : Double)
+data SimpleDataRealizedFunction : (t : Type) -> (cost : Integer) -> (quality : Double)
                                   -> Type where
-  MkSimpleDataRealizedFunction : (f : a -> b) -> (cost : Integer) -> (quality : Double)
-                                 -> SimpleDataRealizedFunction f cost quality
+  MkSimpleDataRealizedFunction : (f : t) -> (cost : Integer) -> (quality : Double)
+                                 -> SimpleDataRealizedFunction t cost quality
 
 -- Perform the composition between 2 simple realized functions.  The
 -- resulting realized function is formed as follows:
@@ -18,14 +18,15 @@ data SimpleDataRealizedFunction : (a -> b) -> (cost : Integer) -> (quality : Dou
 --           (SimpleDataRealizedFunction (a -> b) f_cost f_q) ->
 --           (SimpleDataRealizedFunction (a -> c) (f_cost + g_cost) (min f_q g_q))
 public export
-compose : (SimpleDataRealizedFunction (b -> c) g_cost g_q) ->
+compose : {a : Type} -> {b : Type} -> {c : Type} ->
+          (SimpleDataRealizedFunction (b -> c) g_cost g_q) ->
           (SimpleDataRealizedFunction (a -> b) f_cost f_q) ->
           (SimpleDataRealizedFunction (a -> c) (f_cost + g_cost) (min f_q g_q))
-compose (MkSimpleDataRealizedFunction f) (MkSimpleDataRealizedFunction g) =
-  MkSimpleDataRealizedFunction (f . g)
+compose (MkSimpleDataRealizedFunction f f_cost f_q) (MkSimpleDataRealizedFunction g g_cost g_q) =
+         MkSimpleDataRealizedFunction (f . g) (g_cost + f_cost) (min g_q f_q)
 
 -- Perform function application over realized functions.  Maybe we'd
 -- want to used some funded data, as defined in FndType.
 public export
 apply : (SimpleDataRealizedFunction (a -> b) cost quality) -> a -> b
-apply (MkSimpleDataRealizedFunction f) = f
+apply (MkSimpleDataRealizedFunction f cost quality) = f

--- a/experimental/SimpleDataRealizedFunction.idr
+++ b/experimental/SimpleDataRealizedFunction.idr
@@ -1,6 +1,7 @@
 -- Like SimpleRealizedFunction but uses data instead of record
 
 module SimpleDataRealizedFunction
+%default total
 
 public export
 data SimpleDataRealizedFunction : (t : Type) -> (cost : Integer) -> (quality : Double)


### PR DESCRIPTION
I changed the definition of SimpleDataRealizedFunction slightly to be parameterized on the Type of the function it represents, rather than the function itself (though it still takes that function as an argument to the constructor).  This should allow it to represent functions with any number of arguments, just in case that's required later.

The composition and application functions mostly just needed to have all arguments passed to the MkSimpleDataRealizedFunction constructors.

I've also added %default total to both files, which is something I recommend doing in general unless it starts causing problems in specific cases.