### PR TITLE
Implement RealizedFunction with structured attributes

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -29,7 +29,16 @@ More specifically it contains the following approaches
    `SimpleRealizedFunction.idr` and `SimpleRealizedFunction-test.idr`.
 
 4. `SimpleDataRealizedFunction`: like `SimpleRealizedFunction` but
-   uses `data` instead of `record`.
+   uses `data` instead of `record`.  See
+   `SimpleDataRealizedFunction.idr` and
+   `SimpleDataRealizedFunction-test.idr`.
 
-5. TODO: modular function-based realized dependently typed attributes.
-   This should be what we want and is a work in progress.
+5. `RealizedFunction`: like `SimpleRealizedFunction` but attributes
+   are described in a `RealizedAttributes` data structure instead of
+   being directly described in the type of `RealizedFunction`. This is
+   getting closer to what we want, though it fails to compile for now.
+   See `RealizedAttributes.idr`, `RealizedFunction.idr` and
+   `RealizedFunction-test.idr`.
+
+6. `Service`: more abstract approach using data constructors to
+   compose realized functions rather than standalone functions.

--- a/experimental/RealizedAttributes.idr
+++ b/experimental/RealizedAttributes.idr
@@ -1,8 +1,46 @@
 -- Prototype of RealizedAttributes as described in
 -- https://blog.singularitynet.io/ai-dsl-toward-a-general-purpose-description-language-for-ai-agents-21459f691b9e
+--
+-- This is identical to NonDTRealizedAttributes (up to the name).
+-- Basically I want to see if we can define a RealizedFunction with
+-- such RealizedAttributes as type parameter instead of costs
+-- directly.
 
 module RealizedAttributes
+%default total
 
--- NEXT: used dependent types to type check attributes, take
--- inspiration from NonDTRealizedAttributes.idr and
--- SimpleRealizedFunction.idr
+public export
+CostT : Type
+CostT = Double
+
+public export
+record Costs where
+  constructor MkCosts
+  financial, temporal, computational : CostT
+
+public export
+QualityT : Type
+QualityT = Double
+
+public export
+record RealizedAttributes where
+  constructor MkRealizedAttributes
+  costs : Costs
+  quality : QualityT
+
+-- Add costs
+public export
+add_costs : Costs -> Costs -> Costs
+add_costs x y = MkCosts (x.financial + y.financial)
+                        (x.temporal + y.temporal)
+                        (x.computational + y.computational)
+
+-- Add costs, minimum quality
+public export
+add_costs_min_quality : RealizedAttributes ->
+                        RealizedAttributes ->
+                        RealizedAttributes
+add_costs_min_quality f_attrs g_attrs = fg_attrs where
+  fg_attrs : RealizedAttributes
+  fg_attrs = MkRealizedAttributes (add_costs f_attrs.costs g_attrs.costs)
+                                  (min f_attrs.quality g_attrs.quality)

--- a/experimental/RealizedFunction-test.idr
+++ b/experimental/RealizedFunction-test.idr
@@ -1,25 +1,30 @@
-module Main
+import RealizedFunction
 
-import SimpleRealizedFunction
+%default total
 
 -- Realized incrementer
 incrementer : Int -> Int
 incrementer = (+1)
-rlz_incrementer : SimpleRealizedFunction (Int -> Int) 100 1.0
-rlz_incrementer = MkSimpleRealizedFunction incrementer
+incrementer_attrs : RealizedAttributes
+incrementer_attrs = RealizedAttributes (MkCosts 100 10 1) 1
+rlz_incrementer : SimpleRealizedFunction (Int -> Int) incrementer_attrs
+rlz_incrementer = MkSimpleRealizedFunction incrementer incrementer_attrs
 
 -- Realized twicer
 twicer : Int -> Int
 twicer = (*2)
-rlz_twicer : SimpleRealizedFunction (Int -> Int) 500 0.9
-rlz_twicer = MkSimpleRealizedFunction twicer
+twicer_attrs = MkNonDTRealizedAttributes (MkCosts 200 20 2) 0.9
+rlz_twicer : SimpleRealizedFunction (Int -> Int) twicer_attrs
+rlz_twicer = MkSimpleRealizedFunction twicer twicer_attrs
 
 -- Realized (twicer . incrementer).
-rlz_composition : SimpleRealizedFunction (Int -> Int) 600 0.9
--- The following does not work because 601 ≠ 100+500 and 1.0 ≠ (min 1.0 0.9)
--- rlz_composition : SimpleRealizedFunction (Int -> Int) 601 1.0
+rlz_composition_attrs = MkRealizedAttributes (MkCosts 300 30 3) 0.9
+rlz_composition : RealizedFunction (Int -> Int) rlz_composition_attrs
 rlz_composition = compose rlz_twicer rlz_incrementer
 
 -- Simple test, result should be (3+1)*2 = 8
 rslt : Int
 rslt = apply rlz_composition 3
+
+rsltTest : (rslt 3) = 8
+rsltTest = Refl

--- a/experimental/RealizedFunction.idr
+++ b/experimental/RealizedFunction.idr
@@ -1,8 +1,33 @@
 -- Prototype of RealizedFunction as described in
 -- https://blog.singularitynet.io/ai-dsl-toward-a-general-purpose-description-language-for-ai-agents-21459f691b9e
+--
+-- This is similar to SimpleDataRealizedFunction but the attributes
+-- are wrapped in RealizedAttributes.
 
 module RealizedFunction
 
--- NEXT: used dependent types to type check attributes in realized
--- function, take inspiration from NonDTRealizedFunction.idr and
--- SimpleRealizedFunction.idr
+import public RealizedAttributes
+
+public export
+data RealizedFunction : (t : Type) -> (attrs : RealizedAttributes) -> Type where
+  MkRealizedFunction : (f : t) -> (attrs : RealizedAttributes)
+                       -> RealizedFunction t attrs
+
+-- Perform the composition between 2 realized functions.  The
+-- resulting realized function is formed as follows:
+--
+-- 1. Composed lifted functions
+-- 2. Use add_costs_min_quality for composing attributes
+public export
+compose : {a : Type} -> {b : Type} -> {c : Type} ->
+          (RealizedFunction (b -> c) g_attrs) ->
+          (RealizedFunction (a -> b) f_attrs) ->
+          (RealizedFunction (a -> c) (add_costs_min_quality f_attrs g_attrs))
+compose (MkRealizedFunction f f_attrs) (MkRealizedFunction g g_attrs) =
+  MkRealizedFunction (f . g) (add_costs_min_quality f_attrs g_attrs)
+
+-- Perform function application over realized functions.  Maybe we'd
+-- want to used some funded data, as defined in FndType.
+public export
+apply : (RealizedFunction (a -> b) attrs) -> a -> b
+apply (MkRealizedFunction f attrs) = f

--- a/experimental/SimpleDataRealizedFunction.idr
+++ b/experimental/SimpleDataRealizedFunction.idr
@@ -14,10 +14,7 @@ data SimpleDataRealizedFunction : (t : Type) -> (cost : Integer) -> (quality : D
 --
 -- 1. Composed lifted functions
 -- 2. Costs are added
--- public export
--- compose : (SimpleDataRealizedFunction (b -> c) g_cost g_q) ->
---           (SimpleDataRealizedFunction (a -> b) f_cost f_q) ->
---           (SimpleDataRealizedFunction (a -> c) (f_cost + g_cost) (min f_q g_q))
+-- 3. Composed quality is the min of the component qualities
 public export
 compose : {a : Type} -> {b : Type} -> {c : Type} ->
           (SimpleDataRealizedFunction (b -> c) g_cost g_q) ->


### PR DESCRIPTION
It fails with error msg:

```
- + Errors (1)
 `-- RealizedFunction.idr line 27 col 2:
     While processing right hand side of compose. When unifying prim__add_Double (.financial (.costs f_attrs)) (.financial (.costs g_attrs)) and prim__add_Double (.financial (.costs g_attrs)) (.financial (.costs f_attrs)).
     Mismatch between: g_attrs and f_attrs.

     RealizedFunction.idr:27:3--27:69
         |
      27 |   MkRealizedFunction (f . g) (add_costs_min_quality f_attrs g_attrs)
         |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

but I'm merging it now to have more eyes on it.