### PR TITLE
Complete min proofs

### DIFF
--- a/experimental/ai-algorithms/descent/Descent.idr
+++ b/experimental/ai-algorithms/descent/Descent.idr
@@ -21,6 +21,9 @@ import Data.Vect
 |||
 ||| For now the descent algorithm merely iteratively calls the search
 ||| function as long as the cost function over its output is lower.
+|||
+||| NEXT: explore returning the whole trace.
+||| NEXT: support backtracking (trace is a tree instead of a vector) (look at sorted tree).
 descent_rec : Ord cost_t => cnd_t -> cost_t -> (cnd_t -> cost_t) -> (cnd_t -> cnd_t) -> cnd_t
 descent_rec cnd cst cstfn nxtfn =
   if nxtcst < cst then descent_rec nxtcnd nxtcst cstfn nxtfn

--- a/experimental/ai-algorithms/descent/Descent.idr
+++ b/experimental/ai-algorithms/descent/Descent.idr
@@ -22,8 +22,10 @@ import Data.Vect
 ||| For now the descent algorithm merely iteratively calls the search
 ||| function as long as the cost function over its output is lower.
 |||
-||| NEXT: explore returning the whole trace.
-||| NEXT: support backtracking (trace is a tree instead of a vector) (look at sorted tree).
+||| TODO: explore returning the whole trace.
+|||
+||| TODO: support backtracking (trace is a tree instead of a vector)
+||| (look at sorted tree).
 descent_rec : Ord cost_t => cnd_t -> cost_t -> (cnd_t -> cost_t) -> (cnd_t -> cnd_t) -> cnd_t
 descent_rec cnd cst cstfn nxtfn =
   if nxtcst < cst then descent_rec nxtcnd nxtcst cstfn nxtfn

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -1,5 +1,7 @@
 module MinProof
 
+import Data.Vect
+
 --------------------------------------------------------------------
 -- Excercises to prove                                            --
 --                                                                --
@@ -140,3 +142,17 @@ my_min_lte_prf x y with (x < y) proof eq
              where x_nlte_y : y <= x = False
                    x_nlte_y = gte_converse_complement_prf x y True eq
   _ | False = (gte_converse_complement_prf x y False eq, gte_reflexive_prf y)
+
+-------------------------------------------------------
+-- Assuming a total order, prove that                --
+--                                                   --
+--   If m∈S is a minimal element of S, then ∀s∈S m≤s --
+-------------------------------------------------------
+
+||| Return the minimal element of a vector of at least one element.
+min_element : Ord a => Vect (S n) a -> a
+min_element (x :: []) = x
+min_element (x :: (y :: xs)) = my_min x (min_element (y :: xs))
+
+||| Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
+min_element_lte_prf : Ord a => Vect (S n) a -> ?h

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -1,6 +1,7 @@
 module MinProof
 
 import Data.Vect
+import Data.Vect.Quantifiers
 
 --------------------------------------------------------------------
 -- Excercises to prove                                            --

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -64,8 +64,6 @@ test_my_min_3 = Left Refl
 -- Proofs about my_min --
 -------------------------
 
--- NEXT.-1: do the same of minimal element of a container
-
 -- NEXT.0: see if we can use quantifiers (as in QTT)
 
 -- NEXT.1: redefine LT x y as y < x = True and use interfaces in
@@ -157,22 +155,6 @@ min_element (x :: []) = x
 min_element (x :: (y :: xs)) = my_min x (min_element (y :: xs))
 
 ||| Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
-min_element_le_prf : Ord a => (xs : Vect (S n) a) -> All (?p (min_element xs)) xs
-
--- From Thomas (CodingCellist)
---
--- -- proof that an `Ord` is less-than-or-equal-to another `Ord`
--- data ORD_LTE : Ord t => t -> t -> Type where
---   IsLT :  Ord t
---        => (x : t)
---        -> (y : t)
---        -> {auto 0 prf : (compare x y === LT)}
---        -> ORD_LTE x y
---   IsEQ :  Ord t
---        => (x : t)
---        -> (y : t)
---        -> {auto 0 prf : (compare x y === EQ)}
---        -> ORD_LTE x y
---
--- -- Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
--- min_element_leq_prf : Ord a => (xs : Vect (S n) a) -> All (ORD_LTE (min_element xs)) xs
+min_element_le_prf : Ord a => (xs : Vect (S n) a) -> All (\x : a => (min_element xs) <= x = True) xs
+min_element_le_prf (x :: []) = ge_reflexive_prf x :: []
+min_element_le_prf (x :: (y :: xs)) = fst (my_min_le_prf x (min_element (y :: xs))) :: ?h -- NEXT.3

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -114,7 +114,7 @@ le_strongly_connected_imp_prf : Ord a => {0 x, y : a} -> x <= y = False -> y <= 
 le_strongly_connected_imp_prf _ = believe_me ()
 
 ||| Proof that my_min x y returns either x or y
-my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
+my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y) -- TODO: replace (x, y : a) by {0 x, y : a}, if possible
 my_min_eq_prf x y with (x < y)
   _ | True = Left Refl
   _ | False = Right Refl

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -12,11 +12,12 @@ module MinProof
 -- Alternative implementation of min to have its full control --
 ----------------------------------------------------------------
 
+||| Redefinition of min for more control
 my_min : Ord a => a -> a -> a
-my_min x y = if x < y then x else y -- Maybe try with x <= y
--- my_min x y with (x < y)
---   my_min x y | True = x
---   my_min x y | False = y
+-- my_min x y = if x < y then x else y
+my_min x y with (x < y)
+  _ | True = x
+  _ | False = y
 
 -----------------
 -- Test my_min --

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -75,35 +75,36 @@ test_my_min_3 = Left Refl
 
 ||| Proof that < is irreflexive (not generally true, assumed for now)
 lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
-lt_irreflexive_prf _ = believe_me Void
+lt_irreflexive_prf _ = believe_me ()
 
 ||| Proof that < is asymmetric (not generally true, assumed for now)
 lt_asymmetric_prf : Ord a => (x, y : a) -> x < y = True -> y < x = False
-lt_asymmetric_prf _ _ _ = believe_me Void
+lt_asymmetric_prf _ _ _ = believe_me ()
 
 ||| Proof that < is connected (not generally true, assumed for now)
 lt_connected_prf : Ord a => (x, y : a) -> x < y = False -> y < x = False -> x = y
-lt_connected_prf _ _ _ _ = believe_me Void
+lt_connected_prf _ _ _ _ = believe_me ()
 
 ||| Proof that <= is reflexive (maybe not generally true, assumed for now)
+||| NEXT.-1: Ord a => (x, y : a) -> (x = y) -> (x <= y = True)
 ge_reflexive_prf : Ord a => (x : a) -> x <= x = True
-ge_reflexive_prf _ = believe_me Void
+ge_reflexive_prf _ = believe_me ()
 
 ||| Proof that <= is the complement of the converse of < (not
 ||| generally true, assumed for now)
 ge_converse_complement_prf : Ord a => (x, y : a) -> (b : Bool) -> x < y = b -> y <= x = not b
-ge_converse_complement_prf _ _ _ _ = believe_me Void
+ge_converse_complement_prf _ _ _ _ = believe_me ()
 
 ||| Proof that <= is strongly connected (not generally true, assumed
 ||| for now)
 ge_strongly_connected_prf : Ord a => (x, y : a) -> Either (x <= y = True) (y <= x = True)
-ge_strongly_connected_prf _ _ = believe_me Void
+ge_strongly_connected_prf _ _ = believe_me ()
 
 ||| Implicative form that <= is strongly connected (not generally
 ||| true, assumed for now).  This can perhaps be inferred from
 ||| ge_strongly_connected_prf.
 ge_strongly_connected_imp_prf : Ord a => (x, y : a) -> x <= y = False -> y <= x = True
-ge_strongly_connected_imp_prf _ _ = believe_me Void
+ge_strongly_connected_imp_prf _ _ = believe_me ()
 
 ||| Proof that my_min x y returns either x or y
 my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -72,37 +72,37 @@ test_my_min_3 = Left Refl
 -- NEXT.2: use Not y < x = True instead of y < x = False
 
 ||| Proof that < is irreflexive (not generally true, assumed for now)
-lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
-lt_irreflexive_prf _ = believe_me ()
+lt_irreflexive_prf : Ord a => {0 x : a} -> x < x = False
+lt_irreflexive_prf = believe_me ()
 
 ||| Proof that < is asymmetric (not generally true, assumed for now)
-lt_asymmetric_prf : Ord a => (x, y : a) -> x < y = True -> y < x = False
-lt_asymmetric_prf _ _ _ = believe_me ()
+lt_asymmetric_prf : Ord a => {0 x, y : a} -> x < y = True -> y < x = False
+lt_asymmetric_prf _ = believe_me ()
 
 ||| Proof that < is connected (not generally true, assumed for now)
-lt_connected_prf : Ord a => (x, y : a) -> x < y = False -> y < x = False -> x = y
-lt_connected_prf _ _ _ _ = believe_me ()
+lt_connected_prf : Ord a => {0 x, y : a} -> x < y = False -> y < x = False -> x = y
+lt_connected_prf _ _ = believe_me ()
 
 ||| Proof that <= is reflexive (maybe not generally true, assumed for now)
 ||| NEXT.-1: Ord a => (x, y : a) -> (x = y) -> (x <= y = True)
-ge_reflexive_prf : Ord a => (x : a) -> x <= x = True
-ge_reflexive_prf _ = believe_me ()
+le_reflexive_prf : Ord a => {0 x : a} -> x <= x = True
+le_reflexive_prf = believe_me ()
 
 ||| Proof that <= is the complement of the converse of < (not
 ||| generally true, assumed for now)
-ge_converse_complement_prf : Ord a => (x, y : a) -> (b : Bool) -> x < y = b -> y <= x = not b
-ge_converse_complement_prf _ _ _ _ = believe_me ()
+le_converse_complement_prf : Ord a => {0 x, y : a} -> {0 b : Bool} -> x < y = b -> y <= x = not b
+le_converse_complement_prf _ = believe_me ()
 
 ||| Proof that <= is strongly connected (not generally true, assumed
 ||| for now)
-ge_strongly_connected_prf : Ord a => (x, y : a) -> Either (x <= y = True) (y <= x = True)
-ge_strongly_connected_prf _ _ = believe_me ()
+le_strongly_connected_prf : Ord a => {0 x, y : a} -> Either (x <= y = True) (y <= x = True)
+le_strongly_connected_prf = believe_me ()
 
 ||| Implicative form that <= is strongly connected (not generally
 ||| true, assumed for now).  This can perhaps be inferred from
-||| ge_strongly_connected_prf.
-ge_strongly_connected_imp_prf : Ord a => (x, y : a) -> x <= y = False -> y <= x = True
-ge_strongly_connected_imp_prf _ _ = believe_me ()
+||| le_strongly_connected_prf.
+le_strongly_connected_imp_prf : Ord a => {0 x, y : a} -> x <= y = False -> y <= x = True
+le_strongly_connected_imp_prf _ = believe_me ()
 
 ||| Proof that my_min x y returns either x or y
 my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
@@ -115,8 +115,8 @@ my_min_commutative_prf : Ord a => (x, y : a) -> my_min x y = my_min y x
 my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2
   _ | True | False = Refl
   _ | False | True = Refl
-  _ | False | False = sym (lt_connected_prf x y eq1 eq2)
-  _ | True | True = absurd (trans (sym (lt_asymmetric_prf x y eq1)) eq2)
+  _ | False | False = sym (lt_connected_prf eq1 eq2)
+  _ | True | True = absurd (trans (sym (lt_asymmetric_prf eq1)) eq2)
   -- Below are more decomposed proofs for the absurd and connected cases
   -- _ | True | True = absurd f_eq_t -- eq1 := x < y = True, eq2 := y < x = True
   --                   where f_eq_t : False = True
@@ -124,24 +124,24 @@ my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2
   --                         where f_eq_y_lt_x : False = y < x
   --                               f_eq_y_lt_x = sym y_lt_x_eq_f
   --                               where y_lt_x_eq_f : y < x = False
-  --                                     y_lt_x_eq_f = lt_asymmetric_prf x y eq1
+  --                                     y_lt_x_eq_f = lt_asymmetric_prf eq1
   -- _ | False | False = sym x_eq_y
   --                     where x_eq_y : x = y
-  --                           x_eq_y = lt_connected_prf x y eq1 eq2
+  --                           x_eq_y = lt_connected_prf eq1 eq2
 
 ||| Proof that my_min x y is not greater than x and y
 my_min_ngt_prf : Ord a => (x, y : a) -> (x < my_min x y = False, y < my_min x y = False)
 my_min_ngt_prf x y with (x < y) proof eq
-  _ | True = (lt_irreflexive_prf x, lt_asymmetric_prf x y eq)
-  _ | False = (eq, lt_irreflexive_prf y)
+  _ | True = (lt_irreflexive_prf, lt_asymmetric_prf eq)
+  _ | False = (eq, lt_irreflexive_prf)
 
 ||| Proof that my_min x y is equal to or lower than x and y
 my_min_le_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
 my_min_le_prf x y with (x < y) proof eq
-  _ | True = (ge_reflexive_prf x, ge_strongly_connected_imp_prf y x x_nle_y)
+  _ | True = (le_reflexive_prf, le_strongly_connected_imp_prf x_nle_y)
              where x_nle_y : y <= x = False
-                   x_nle_y = ge_converse_complement_prf x y True eq
-  _ | False = (ge_converse_complement_prf x y False eq, ge_reflexive_prf y)
+                   x_nle_y = le_converse_complement_prf eq
+  _ | False = (le_converse_complement_prf eq, le_reflexive_prf)
 
 -------------------------------------------------------
 -- Assuming a total order, prove that                --

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -85,24 +85,24 @@ lt_connected_prf : Ord a => (x, y : a) -> x < y = False -> y < x = False -> x = 
 lt_connected_prf _ _ _ _ = believe_me Void
 
 ||| Proof that <= is reflexive (maybe not generally true, assumed for now)
-gte_reflexive_prf : Ord a => (x : a) -> x <= x = True
-gte_reflexive_prf _ = believe_me Void
+ge_reflexive_prf : Ord a => (x : a) -> x <= x = True
+ge_reflexive_prf _ = believe_me Void
 
 ||| Proof that <= is the complement of the converse of < (not
 ||| generally true, assumed for now)
-gte_converse_complement_prf : Ord a => (x, y : a) -> (b : Bool) -> x < y = b -> y <= x = not b
-gte_converse_complement_prf _ _ _ _ = believe_me Void
+ge_converse_complement_prf : Ord a => (x, y : a) -> (b : Bool) -> x < y = b -> y <= x = not b
+ge_converse_complement_prf _ _ _ _ = believe_me Void
 
 ||| Proof that <= is strongly connected (not generally true, assumed
 ||| for now)
-gte_strongly_connected_prf : Ord a => (x, y : a) -> Either (x <= y = True) (y <= x = True)
-gte_strongly_connected_prf _ _ = believe_me Void
+ge_strongly_connected_prf : Ord a => (x, y : a) -> Either (x <= y = True) (y <= x = True)
+ge_strongly_connected_prf _ _ = believe_me Void
 
 ||| Implicative form that <= is strongly connected (not generally
 ||| true, assumed for now).  This can perhaps be inferred from
-||| gte_strongly_connected_prf.
-gte_strongly_connected_imp_prf : Ord a => (x, y : a) -> x <= y = False -> y <= x = True
-gte_strongly_connected_imp_prf _ _ = believe_me Void
+||| ge_strongly_connected_prf.
+ge_strongly_connected_imp_prf : Ord a => (x, y : a) -> x <= y = False -> y <= x = True
+ge_strongly_connected_imp_prf _ _ = believe_me Void
 
 ||| Proof that my_min x y returns either x or y
 my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
@@ -136,12 +136,12 @@ my_min_ngt_prf x y with (x < y) proof eq
   _ | False = (eq, lt_irreflexive_prf y)
 
 ||| Proof that my_min x y is equal to or lower than x and y
-my_min_lte_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
-my_min_lte_prf x y with (x < y) proof eq
-  _ | True = (gte_reflexive_prf x, gte_strongly_connected_imp_prf y x x_nlte_y)
-             where x_nlte_y : y <= x = False
-                   x_nlte_y = gte_converse_complement_prf x y True eq
-  _ | False = (gte_converse_complement_prf x y False eq, gte_reflexive_prf y)
+my_min_le_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
+my_min_le_prf x y with (x < y) proof eq
+  _ | True = (ge_reflexive_prf x, ge_strongly_connected_imp_prf y x x_nle_y)
+             where x_nle_y : y <= x = False
+                   x_nle_y = ge_converse_complement_prf x y True eq
+  _ | False = (ge_converse_complement_prf x y False eq, ge_reflexive_prf y)
 
 -------------------------------------------------------
 -- Assuming a total order, prove that                --
@@ -155,4 +155,4 @@ min_element (x :: []) = x
 min_element (x :: (y :: xs)) = my_min x (min_element (y :: xs))
 
 ||| Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
-min_element_lte_prf : Ord a => Vect (S n) a -> ?h
+min_element_le_prf : Ord a => (xs : Vect (S n) a) -> All (?p (min_element xs)) xs

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -94,5 +94,6 @@ my_min_ngt_prf x y with (x < y) proof eq
 
 ||| Proof that my_min x y is equal to or lower than x and y
 my_min_lte_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
-my_min_lte_prf x y = believe_me Void  -- NEXT.3
-
+my_min_lte_prf x y with (x < y) proof eq
+  _ | True = (gte_reflexive_prf x, ?h)  -- NEXT.3: x < y = True -> x <= y = True
+  _ | False = (gte_converse_complement_prf x y eq, gte_reflexive_prf y)

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -1,16 +1,44 @@
 module MinProof
 
----------------------------------------------------------------
--- Excercises to prove                                       --
---                                                           --
--- min(x, y) <= x and min(x, y) <= y                         --
---                                                           --
--- and a few other properties like commutativity.            --
----------------------------------------------------------------
+--------------------------------------------------------------------
+-- Excercises to prove                                            --
+--                                                                --
+--   min(x, y) ≤ x and min(x, y) ≤ y                              --
+--                                                                --
+-- and other properties like commutativity.                       --
+--                                                                --
+-- According to                                                   --
+--                                                                --
+-- https://en.wikipedia.org/wiki/Maximal_and_minimal_elements     --
+--                                                                --
+-- The minimal element m of set S, is defined such that           --
+--                                                                --
+--   ∀s∈S, if s ≤ m then m ≤ s                                    --
+--                                                                --
+-- given as only assumption about ≤ that it is a preorder,        --
+-- i.e. reflexive and transitive.                                 --
+--                                                                --
+-- Thus in our case, strictly following the definition, what we   --
+-- want to ensure is that                                         --
+--                                                                --
+--   if x ≤ min(x, y) then min(x, y) ≤ x                          --
+--   if y ≤ min(x, y) then min(x, y) ≤ y                          --
+--                                                                --
+-- If ≤ is antisymmetric, i.e. a partial order, then it becomes   --
+--                                                                --
+--   if x ≤ min(x, y) then min(x, y) = x                          --
+--   if y ≤ min(x, y) then min(x, y) = y                          --
+--                                                                --
+-- Finally if ≤ is total, then it follows that                    --
+--                                                                --
+--   min(x, y) ≤ x and min(x, y) ≤ y                              --
+--                                                                --
+-- which is what we set out to prove at the beginning.            --
+--------------------------------------------------------------------
 
-----------------------------------------------------------------
--- Alternative implementation of min to have its full control --
-----------------------------------------------------------------
+---------------------------------------
+-- Alternative implementation of min --
+---------------------------------------
 
 ||| Redefinition of min for full control
 my_min : Ord a => a -> a -> a
@@ -78,7 +106,7 @@ my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2
   -- _ | True | True = absurd f_eq_t -- eq1 := x < y = True, eq2 := y < x = True
   --                   where f_eq_t : False = True
   --                         f_eq_t = trans f_eq_y_lt_x eq2
-  --                         where f_eq_y_lt_x : False = y < x /\ y < x = True
+  --                         where f_eq_y_lt_x : False = y < x
   --                               f_eq_y_lt_x = sym y_lt_x_eq_f
   --                               where y_lt_x_eq_f : y < x = False
   --                                     y_lt_x_eq_f = lt_asymmetric_prf x y eq1

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -52,6 +52,10 @@ lt_asymmetric_prf _ _ _ = believe_me Void
 lt_connected_prf : Ord a => (x, y : a) -> x < y = False -> y < x = False -> x = y
 lt_connected_prf _ _ _ _ = believe_me Void
 
+||| Proof that < is irreflexive (not generally true, assumed for now)
+lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
+lt_irreflexive_prf _ = believe_me Void
+
 ||| Proof that my_min is commutative
 my_min_commutative_prf : Ord a => (x, y: a) -> my_min x y = my_min y x
 my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -40,11 +40,9 @@ test_my_min_3 = Left Refl
 
 -- NEXT.2: use Not y < x = True instead of y < x = False
 
-||| Proof that my_min x y returns either x or y
-my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
-my_min_eq_prf x y with (x < y)
-  _ | True = Left Refl
-  _ | False = Right Refl
+||| Proof that < is irreflexive (not generally true, assumed for now)
+lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
+lt_irreflexive_prf _ = believe_me Void
 
 ||| Proof that < is asymmetric (not generally true, assumed for now)
 lt_asymmetric_prf : Ord a => (x, y : a) -> x < y = True -> y < x = False
@@ -54,9 +52,20 @@ lt_asymmetric_prf _ _ _ = believe_me Void
 lt_connected_prf : Ord a => (x, y : a) -> x < y = False -> y < x = False -> x = y
 lt_connected_prf _ _ _ _ = believe_me Void
 
-||| Proof that < is irreflexive (not generally true, assumed for now)
-lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
-lt_irreflexive_prf _ = believe_me Void
+||| Proof that <= is reflexive (maybe not generally true, assumed for now)
+gte_reflexive_prf : Ord a => (x : a) -> x <= x = True
+gte_reflexive_prf _ = believe_me Void
+
+||| Proof that <= is the complement of the converse of < (not
+||| generally true, assumed for now)
+gte_converse_complement_prf : Ord a => (x, y : a) -> x < y = False -> y <= x = True
+gte_converse_complement_prf _ _ _ = believe_me Void
+
+||| Proof that my_min x y returns either x or y
+my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
+my_min_eq_prf x y with (x < y)
+  _ | True = Left Refl
+  _ | False = Right Refl
 
 ||| Proof that my_min is commutative
 my_min_commutative_prf : Ord a => (x, y : a) -> my_min x y = my_min y x

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -84,9 +84,18 @@ lt_connected_prf : Ord a => {0 x, y : a} -> x < y = False -> y < x = False -> x 
 lt_connected_prf _ _ = believe_me ()
 
 ||| Proof that <= is reflexive (maybe not generally true, assumed for now)
-||| NEXT.-1: Ord a => (x, y : a) -> (x = y) -> (x <= y = True)
 le_reflexive_prf : Ord a => {0 x : a} -> x <= x = True
 le_reflexive_prf = believe_me ()
+
+||| Proof that <= is transitive (not generally true, assumed for now)
+le_transitive_prf : Ord a => {0 x, y, z : a} -> x <= y = True -> y <= z = True -> x <= z = True
+le_transitive_prf _ _ = believe_me ()
+
+||| Proof that <= is the reflexive closure of < (or conversely that <
+||| is the irreflexive kernel of <=).  Not generally true, assumed for
+||| now.
+le_reflexive_closure_lt_prf : Ord a => {0 x, y : a} -> Either (x < y = True) (x = y) -> x <= y = True
+le_reflexive_closure_lt_prf _ = believe_me ()
 
 ||| Proof that <= is the complement of the converse of < (not
 ||| generally true, assumed for now)
@@ -152,9 +161,17 @@ my_min_le_prf x y with (x < y) proof eq
 ||| Return the minimal element of a vector of at least one element.
 min_element : Ord a => Vect (S n) a -> a
 min_element (x :: []) = x
-min_element (x :: (y :: xs)) = my_min x (min_element (y :: xs))
+min_element (x :: (y :: ys)) = my_min x (min_element (y :: ys))
 
 ||| Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
 min_element_le_prf : Ord a => (xs : Vect (S n) a) -> All (\x : a => (min_element xs) <= x = True) xs
-min_element_le_prf (x :: []) = ge_reflexive_prf x :: []
-min_element_le_prf (x :: (y :: xs)) = fst (my_min_le_prf x (min_element (y :: xs))) :: ?h -- NEXT.3
+min_element_le_prf (x :: []) = le_reflexive_prf :: []
+min_element_le_prf (x :: (y :: ys)) = head_prf :: tail_prf
+  where head_prf : (min_element (x :: (y :: ys))) <= x = True
+        head_prf = fst (my_min_le_prf x (min_element (y :: ys)))
+        tail_prf : All (\z : a => (min_element (x :: (y :: ys))) <= z = True) (y :: ys)
+        tail_prf = mapProperty prf_f (min_element_le_prf (y :: ys))
+        where prf_f : {0 w : a} -> min_element (y :: ys) <= w = True -> min_element (x :: (y :: ys)) <= w = True
+              prf_f prf with (x < min_element (y :: ys)) proof eq
+                _ | True = le_transitive_prf (le_reflexive_closure_lt_prf (Left eq)) prf
+                _ | False = prf

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -12,12 +12,9 @@ module MinProof
 -- Alternative implementation of min to have its full control --
 ----------------------------------------------------------------
 
-||| Redefinition of min for more control
+||| Redefinition of min for full control
 my_min : Ord a => a -> a -> a
--- my_min x y = if x < y then x else y
-my_min x y with (x < y)
-  _ | True = x
-  _ | False = y
+my_min x y = if x < y then x else y
 
 -----------------
 -- Test my_min --

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -57,7 +57,7 @@ lt_irreflexive_prf : Ord a => (x : a) -> x < x = False
 lt_irreflexive_prf _ = believe_me Void
 
 ||| Proof that my_min is commutative
-my_min_commutative_prf : Ord a => (x, y: a) -> my_min x y = my_min y x
+my_min_commutative_prf : Ord a => (x, y : a) -> my_min x y = my_min y x
 my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2
   _ | True | False = Refl
   _ | False | True = Refl

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -64,12 +64,10 @@ test_my_min_3 = Left Refl
 -- Proofs about my_min --
 -------------------------
 
--- NEXT.0: see if we can use quantifiers (as in QTT)
-
--- NEXT.1: redefine LT x y as y < x = True and use interfaces in
+-- TODO: redefine LT x y as y < x = True and use interfaces in
 -- Control.Relation and Decidable.Order.Strict
 
--- NEXT.2: use Not y < x = True instead of y < x = False
+-- TODO: use Not y < x = True instead of y < x = False
 
 ||| Proof that < is irreflexive (not generally true, assumed for now)
 lt_irreflexive_prf : Ord a => {0 x : a} -> x < x = False
@@ -114,7 +112,7 @@ le_strongly_connected_imp_prf : Ord a => {0 x, y : a} -> x <= y = False -> y <= 
 le_strongly_connected_imp_prf _ = believe_me ()
 
 ||| Proof that my_min x y returns either x or y
-my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y) -- TODO: replace (x, y : a) by {0 x, y : a}, if possible
+my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
 my_min_eq_prf x y with (x < y)
   _ | True = Left Refl
   _ | False = Right Refl

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -152,6 +152,12 @@ my_min_le_prf x y with (x < y) proof eq
                    x_nle_y = le_converse_complement_prf eq
   _ | False = (le_converse_complement_prf eq, le_reflexive_prf)
 
+||| Minimum function decorated with the proof of its correctness.
+||| This is to explore the pros and cons of having the specification
+||| inside the type signature of the function.
+my_min_with_prf : Ord a => (x, y : a) -> (m : a ** (m <= x = True, m <= y = True))
+my_min_with_prf x y = (my_min x y ** my_min_le_prf x y)
+
 -------------------------------------------------------
 -- Assuming a total order, prove that                --
 --                                                   --
@@ -175,3 +181,9 @@ min_element_le_prf (x :: (y :: ys)) = head_prf :: tail_prf
               prf_f prf with (x < min_element (y :: ys)) proof eq
                 _ | True = le_transitive_prf (le_reflexive_closure_lt_prf (Left eq)) prf
                 _ | False = prf
+
+||| Minimal element function decorated with the proof of its
+||| correctness.  This is to explore the pros and cons of having the
+||| specification inside the type signature of the function.
+min_element_with_prf : Ord a => (xs : Vect (S n) a) -> (m : a ** All (\x : a => m <= x = True) xs)
+min_element_with_prf xs = (min_element xs ** min_element_le_prf xs)

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -33,16 +33,16 @@ test_my_min_3 = Left Refl
 -- Proofs about my_min --
 -------------------------
 
+-- NEXT.1: Redefine LT x y as y < x = True and use interfaces in
+-- Control.Relation and Decidable.Order.Strict
+
+-- NEXT.2: use Not y < x = True instead of y < x = False
+
 ||| Proof that my_min x y returns either x or y
 my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
 my_min_eq_prf x y with (x < y)
   _ | True = Left Refl
   _ | False = Right Refl
-
--- NEXT.1: Redefine LT x y as y < x = True and use interfaces in
--- Control.Relation and Decidable.Order.Strict
-
--- NEXT.2: use Not y < x = True instead of y < x = False
 
 ||| Proof that < is asymmetric (not generally true, assumed for now)
 lt_asymmetric_prf : Ord a => (x, y : a) -> x < y = True -> y < x = False

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -42,7 +42,10 @@ my_min_eq_prf x y with (x < y)
   _ | True = Left Refl
   _ | False = Right Refl
 
--- NEXT: study Decidable.Order.Strict, for more constrained Ord
+-- NEXT.1: Redefine LT x y as y < x = True and use interfaces in
+-- Control.Relation and Decidable.Order.Strict
+
+-- NEXT.2: use Not y < x = True instead of y < x = False
 
 ||| Proof that < is asymmetric (not generally true, assumed for now)
 lt_asymmetric_prf : Ord a => (x, y : a) -> x < y = True -> y < x = False

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -78,13 +78,15 @@ my_min_commutative_prf x y with (x < y) proof eq1 | (y < x) proof eq2
   --                     where x_eq_y : x = y
   --                           x_eq_y = lt_connected_prf x y eq1 eq2
 
-||| Proof that my_min x y is equal to or lower than x and y
-my_min_lte_prf : Ord a => (x, y: a) -> (((my_min x y <= x) = True), ((my_min x y <= y) = True))
-my_min_lte_prf x y = believe_me Void
-
 ||| Proof that my_min x y is not greater than x and y
-my_min_ngt_prf : Ord a => (x, y: a) -> (x < (min x y) = False, y < (min x y) = False)
-my_min_ngt_prf x y = believe_me Void -- NEXT
+my_min_ngt_prf : Ord a => (x, y : a) -> (x < my_min x y = False, y < my_min x y = False)
+my_min_ngt_prf x y with (x < y) proof eq
+  _ | True = (lt_irreflexive_prf x, lt_asymmetric_prf x y eq)
+  _ | False = (eq, lt_irreflexive_prf y)
+
+||| Proof that my_min x y is equal to or lower than x and y
+my_min_lte_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
+my_min_lte_prf x y = believe_me Void  -- NEXT.3
 
 -- -- From Stefan Höck, for more see
 -- -- https://github.com/stefan-hoeck/idris2-prim

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -61,6 +61,8 @@ test_my_min_3 = Left Refl
 -- Proofs about my_min --
 -------------------------
 
+-- NEXT.-1: do the same of minimal element of a container
+
 -- NEXT.0: see if we can use quantifiers (as in QTT)
 
 -- NEXT.1: redefine LT x y as y < x = True and use interfaces in
@@ -86,8 +88,19 @@ gte_reflexive_prf _ = believe_me Void
 
 ||| Proof that <= is the complement of the converse of < (not
 ||| generally true, assumed for now)
-gte_converse_complement_prf : Ord a => (x, y : a) -> x < y = False -> y <= x = True
-gte_converse_complement_prf _ _ _ = believe_me Void
+gte_converse_complement_prf : Ord a => (x, y : a) -> (b : Bool) -> x < y = b -> y <= x = not b
+gte_converse_complement_prf _ _ _ _ = believe_me Void
+
+||| Proof that <= is strongly connected (not generally true, assumed
+||| for now)
+gte_strongly_connected_prf : Ord a => (x, y : a) -> Either (x <= y = True) (y <= x = True)
+gte_strongly_connected_prf _ _ = believe_me Void
+
+||| Implicative form that <= is strongly connected (not generally
+||| true, assumed for now).  This can perhaps be inferred from
+||| gte_strongly_connected_prf.
+gte_strongly_connected_imp_prf : Ord a => (x, y : a) -> x <= y = False -> y <= x = True
+gte_strongly_connected_imp_prf _ _ = believe_me Void
 
 ||| Proof that my_min x y returns either x or y
 my_min_eq_prf : Ord a => (x, y : a) -> Either (my_min x y = x) (my_min x y = y)
@@ -123,5 +136,7 @@ my_min_ngt_prf x y with (x < y) proof eq
 ||| Proof that my_min x y is equal to or lower than x and y
 my_min_lte_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
 my_min_lte_prf x y with (x < y) proof eq
-  _ | True = (gte_reflexive_prf x, ?h)  -- NEXT.3: x < y = True -> x <= y = True
-  _ | False = (gte_converse_complement_prf x y eq, gte_reflexive_prf y)
+  _ | True = (gte_reflexive_prf x, gte_strongly_connected_imp_prf y x x_nlte_y)
+             where x_nlte_y : y <= x = False
+                   x_nlte_y = gte_converse_complement_prf x y True eq
+  _ | False = (gte_converse_complement_prf x y False eq, gte_reflexive_prf y)

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -33,7 +33,9 @@ test_my_min_3 = Left Refl
 -- Proofs about my_min --
 -------------------------
 
--- NEXT.1: Redefine LT x y as y < x = True and use interfaces in
+-- NEXT.0: see if we can use quantifiers (as in QTT)
+
+-- NEXT.1: redefine LT x y as y < x = True and use interfaces in
 -- Control.Relation and Decidable.Order.Strict
 
 -- NEXT.2: use Not y < x = True instead of y < x = False
@@ -85,40 +87,3 @@ my_min_ngt_prf x y with (x < y) proof eq
 my_min_lte_prf : Ord a => (x, y : a) -> (my_min x y <= x = True, my_min x y <= y = True)
 my_min_lte_prf x y = believe_me Void  -- NEXT.3
 
--- -- From Stefan Höck, for more see
--- -- https://github.com/stefan-hoeck/idris2-prim
-
--- -- ||| This is unsafe! We could well implement `Ord` in such a
--- -- ||| way that this does not hold!
--- OrdLaw1 : Ord a => (0 x,y : a) -> (0 prf : (x < y) === False) -> (y <= x) === True
--- OrdLaw1 _ _ _ = believe_me Void
-
--- ||| This is unsafe! We could well implement `Ord` in such a
--- ||| way that this does not hold!
--- OrdLaw2 : Ord a => (0 x : a) -> (x <= x) === True
--- OrdLaw2 _ = believe_me Void
-
--- MyMinLaw2 : Ord a => (x,y : a) -> (my_min x y <= x) === True
--- MyMinLaw2 x y with (x < y) proof prf
---   MyMinLaw2 x y | True  = OrdLaw2 x
---   MyMinLaw2 x y | False = OrdLaw1 x y prf
-
--- From gallais
-
--- Today at 3:12 PM
--- hmm, that's weird:
---
--- my_min_commutative_prf x y
---   with (lt_asymmetric_prf x y) | (y < x) | (x < y)
---
---
--- is rejected but
---
--- my_min_commutative_prf x y
---   with (lt_asymmetric_prf x y) | (y < x)
---   _ | prf | p with (x < y)
---     _ | q = ?a
---
---
--- is accepted
--- (they should be equivalent)

--- a/experimental/ai-algorithms/descent/MinProof.idr
+++ b/experimental/ai-algorithms/descent/MinProof.idr
@@ -157,3 +157,21 @@ min_element (x :: (y :: xs)) = my_min x (min_element (y :: xs))
 
 ||| Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
 min_element_le_prf : Ord a => (xs : Vect (S n) a) -> All (?p (min_element xs)) xs
+
+-- From Thomas (CodingCellist)
+--
+-- -- proof that an `Ord` is less-than-or-equal-to another `Ord`
+-- data ORD_LTE : Ord t => t -> t -> Type where
+--   IsLT :  Ord t
+--        => (x : t)
+--        -> (y : t)
+--        -> {auto 0 prf : (compare x y === LT)}
+--        -> ORD_LTE x y
+--   IsEQ :  Ord t
+--        => (x : t)
+--        -> (y : t)
+--        -> {auto 0 prf : (compare x y === EQ)}
+--        -> ORD_LTE x y
+--
+-- -- Proof that min_element [x₁, ..., xₙ] is equal to or lower than x₁ to xₙ
+-- min_element_leq_prf : Ord a => (xs : Vect (S n) a) -> All (ORD_LTE (min_element xs)) xs


### PR DESCRIPTION
Complete proofs of correctness of the minimum and minimal element functions.

The proofs are first defined outside of the function type signatures, then added to it (for the sake of experimentation).