### PR TITLE
Program synthesis experiments using Idris2 proof search

### DIFF
--- a/experimental/program-synthesis/idris-proofsearch/PSAST.idr
+++ b/experimental/program-synthesis/idris-proofsearch/PSAST.idr
@@ -1,0 +1,66 @@
+module PSAST
+
+import Data.Vect
+
+-- Represent programs as abstract syntax trees and use Idris proof
+-- search functionality to build them as to be consistent with their
+-- types, i.e. to perform program synthesis.
+--
+-- That code is heavily inspired by
+-- https://github.com/idris-lang/Idris2/blob/main/samples/Interp.idr
+
+||| Dummy candidate type
+data Candidate : Type where
+  MkCandidate : Candidate
+
+||| AST types
+data Ty = TyDouble | TyCandidate | TyFun Ty Ty
+
+||| Type interpreter
+interpTy : Ty -> Type
+interpTy TyDouble    = Double
+interpTy TyCandidate = Candidate
+interpTy (TyFun a t) = interpTy a -> interpTy t
+
+||| Associate variables to types
+data HasType : (i : Fin n) -> Vect n Ty -> Ty -> Type where
+    Stop : HasType FZ (t :: ctxt) t
+    Pop  : HasType k ctxt t -> HasType (FS k) (u :: ctxt) t
+
+||| Abstract Syntax Tree definition.  Operators are very specialized,
+||| such as Descent.  The point is just to demonstrate that it works.
+data Expr : Vect n Ty -> Ty -> Type where
+    DummyCandidate : Expr ctxt TyCandidate
+    LinLoss : Expr ctxt (TyFun TyCandidate TyDouble)
+    LinGradient : Expr ctxt (TyFun TyCandidate TyCandidate)
+    LogLoss : Expr ctxt (TyFun TyCandidate TyDouble)
+    LogGradient : Expr ctxt (TyFun TyCandidate TyCandidate)
+    Descent : Expr ctxt (TyFun TyCandidate TyDouble) ->     -- Cost function
+              Expr ctxt (TyFun TyCandidate TyCandidate) ->  -- Next function
+              Expr ctxt TyCandidate ->                      -- Initial candidate
+              Expr ctxt TyCandidate                         -- Final candidate
+
+||| Environment, variables and their types
+data Env : Vect n Ty -> Type where
+    Nil  : Env Nil
+    (::) : interpTy a -> Env ctxt -> Env (a :: ctxt)
+
+||| Look up the type of a variable
+lookup : HasType i ctxt t -> Env ctxt -> interpTy t
+lookup Stop    (x :: xs) = x
+lookup (Pop k) (x :: xs) = lookup k xs
+
+||| Interpreter.  Not useful for that experiment.
+interp : Env ctxt -> Expr ctxt t -> interpTy t
+interp env DummyCandidate = MkCandidate
+interp env LinLoss = ?linloss
+interp env LinGradient = ?lingrad
+interp env LogLoss = ?logloss
+interp env LogGradient = ?loggrad
+interp env (Descent cost next cnd) = ?descent
+
+||| Idris proof search functionality is able to build the desired program
+|||
+||| Descent LinLoss LinGradient DummyCandidate
+linearRegression : Expr ctxt TyCandidate
+linearRegression = ?lr

--- a/experimental/program-synthesis/idris-proofsearch/PSLet.idr
+++ b/experimental/program-synthesis/idris-proofsearch/PSLet.idr
@@ -1,0 +1,25 @@
+module PSLet
+
+-- Try (but fail) to use Idris let construct to bring to-be-composed
+-- functions into the scope of Idris proof search.
+
+-- Failed attempt.  f and g do not appear in the scope of ?letsyn_h
+letsyn1 : Bool -> Double
+letsyn1 x = let f : Bool -> Int
+                f True = 1
+                f False = 0
+                g : Int -> Double
+                g = cast
+            in ?letsyn1_h
+
+-- Successful attempt.  However it is not much better than syn0b or
+-- syn1b in PSVar.idr as f and g could simply be replaced by holes.
+letsyn2 : Bool -> Double
+letsyn2 x = let f : Bool -> Int
+                f True = 1
+                f False = 0
+                g : Int -> Double
+                g = cast
+            in (\fv : (Bool -> Int),
+                 gv : (Int -> Double)
+                 => (the Double ?letsyn2_h)) f g

--- a/experimental/program-synthesis/idris-proofsearch/PSVar.idr
+++ b/experimental/program-synthesis/idris-proofsearch/PSVar.idr
@@ -1,0 +1,64 @@
+module PSVar
+
+-- Represent to-be-composed functions as variables of a meta-function,
+-- and use Idris proof search functionality to compose them as to be
+-- consistent with the type of the meta-function.
+
+----------------------
+-- Trivial attempts --
+----------------------
+
+-- Succeeds to discover the correct program: g (f x)
+syn0a : (Bool -> Int) -> (Int -> Double) -> Bool -> Double
+syn0a f g x = ?syn0a_h
+
+-- Like above but move the variables in a lambda.  Successful too.
+syn0b : Bool -> Double
+syn0b x = (\f : (Bool -> Int),
+            g : (Int -> Double)
+            => (the Double ?syn0b_h)) ?syn0b_hf ?syn0b_hg
+
+-- Here 3 solutions are possible, f x, g x and h x.  Idris proof
+-- search successfully discover them.
+syn1a : (a -> b -> c) -> (a -> b -> c) -> (a -> b -> c) -> a -> b -> c
+syn1a f g h x y = ?syn1a_rhs
+
+-- Like above but move the variables in a lambda.  Successful too.
+syn1b : a -> b -> c
+syn1b x y = (\f : (a -> b -> c),
+              g : (a -> b -> c),
+              h : (a -> b -> c)
+              => (the c ?syn1b_h)) ?syn1b_hf ?syn1b_hg ?syn1b_hh
+
+-- Succeeds to discover the correct program: f x y z
+syn2 : (a -> b -> c -> d) -> a -> b -> c -> d
+syn2 f x y z = ?synb_rhs
+
+-------------------------------------------------------------------------
+-- Less trivial attempts.  Try synthesize composition of descent, loss --
+-- and gradient.                                                       --
+-------------------------------------------------------------------------
+
+-- Fails as Idris proofsearch gets lost in the wrong branch
+syn3 : ((cnd -> cost) -> (cnd -> cnd) -> cnd -> cnd) -> -- Descent algorithm
+       (cnd -> cost) ->                                 -- Cost function
+       (cnd -> cnd) ->                                  -- Next function
+       cnd ->                                           -- Initial candidate
+       cnd                                              -- Final candidate
+syn3 d c n i = ?syn3_rhs
+
+-- Fails too as Idris proofsearch gets lost in the wrong branch
+syn4 : (cnd -> cost) ->                                 -- Cost function
+       (cnd -> cnd) ->                                  -- Next function
+       cnd ->                                           -- Initial candidate
+       ((cnd -> cost) -> (cnd -> cnd) -> cnd -> cnd) -> -- Descent algorithm
+       cnd                                              -- Final candidate
+syn4 c n i d = ?syn4_h
+
+-- Succeeds as Idris proofsearch starts with the right branch
+syn5 : (cnd -> cnd) ->                                  -- Next function
+       ((cnd -> cost) -> (cnd -> cnd) -> cnd -> cnd) -> -- Descent algorithm
+       (cnd -> cost) ->                                 -- Cost function
+       cnd ->                                           -- Initial candidate
+       cnd                                              -- Final candidate
+syn5 n d c i = ?syn5_h

--- a/experimental/program-synthesis/idris-proofsearch/README.md
+++ b/experimental/program-synthesis/idris-proofsearch/README.md
@@ -1,0 +1,69 @@
+# Program synthesis via Idris proof search
+
+Since recently, Idris2 has introduced a form of program synthesis,
+albeit with important limitations.  In these experiments we explore
+how to use this functionality.
+
+## Requirements
+
+We recommend to access Idris2 proof search via the idris2-lsp server,
+see https://github.com/idris-community/idris2-lsp.
+
+Otherwise you may still use the `:ps` and `:psnext` meta-command of
+the REPL, but they are, as of 2022-10-18, somewhat buggy.  See
+https://github.com/idris-lang/Idris2/issues/2711 for more info.
+
+We also recommend that you use a fairly recent version of Idris2.  The
+one used in these experiments is obtained directly by compiling the
+head of Idris2 from https://github.com/idris-lang/Idris2, revision
+6823915dd to be precise.  Any existing releases, as of today, do not
+support proof search.
+
+## Content
+
+The main limitation of Idris proof search is that it does not have
+access to the data structures and the functions defined in the current
+module or imported modules.  In order to work around that we have
+tried 3 different approaches, 2 successful, 1 not.
+
+The following approaches can be found in the following files:
+
+1. `PSAST.idr`: using Abstract Syntax Trees to represent programs,
+   functions can be placed directly in such AST definition and Idris2
+   can uses these to synthesize programs.
+
+2. `PSVar.idr`: representing functions as variables, a function can be
+   described as its type definition (which should be enough given the
+   powerful type system of Idris), and Idris can combine these
+   variables to synthesize programs.
+
+3. `PSLet.idr`: the idea was to use `let` to expend the scope of proof
+   search beyond constructors and variables, but it did not work.
+
+## Usage
+
+### With the Idris LSP server (recommended)
+
+Point to the hole to fill and call the LSP code action
+
+```
+Expression search
+```
+
+How to do that precisely depends on your IDE.
+
+### With the REPL (not recommended)
+
+Load the file in the Idris2 REPL and call
+
+```
+:ps HOLE_LINE_NUMBER HOLE_NAME
+```
+
+to get the first candidate.  Then call
+
+```
+:psnext
+```
+
+to get subsequent candidates, but it may not work.

--- a/experimental/program-synthesis/idris-proofsearch/idris-proofsearch.ipkg
+++ b/experimental/program-synthesis/idris-proofsearch/idris-proofsearch.ipkg
@@ -1,0 +1,49 @@
+package idris-proofsearch
+version = 0.1
+authors = "Nil Geisweiller"
+-- maintainers =
+-- license =
+-- brief =
+-- readme =
+-- homepage =
+-- sourceloc =
+-- bugtracker =
+
+-- the Idris2 version required (e.g. langversion >= 0.5.1)
+-- langversion
+
+-- packages to add to search path
+depends = contrib
+
+-- modules to install
+modules = PSAST,
+          PSVar,
+          PSLet
+
+-- main file (i.e. file to load at REPL)
+-- main =
+
+-- name of executable
+-- executable =
+-- opts =
+sourcedir = "."
+-- builddir =
+-- outputdir =
+
+-- script to run before building
+-- prebuild =
+
+-- script to run after building
+-- postbuild =
+
+-- script to run after building, before installing
+-- preinstall =
+
+-- script to run after installing
+-- postinstall =
+
+-- script to run before cleaning
+-- preclean =
+
+-- script to run after cleaning
+-- postclean =


### PR DESCRIPTION
Collection of experiments to use Idris2 proof search functionality to perform program synthesis with various levels of success.  See https://github.com/ngeiswei/ai-dsl/blob/proto-program-synthesis/experimental/program-synthesis/idris-proofsearch/README.md for more info.